### PR TITLE
Add offline support with server restart

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -7,11 +7,12 @@ type Config struct {
 
 // Server stores all server related configuration
 type Server struct {
-	Tls         *Tls   `json:"tls" yaml:"tls"`
-	TcpAddress  string `json:"tcp,omitempty" yaml:"tcp,omitempty"`
-	HttpAddress string `json:"http,omitempty" yaml:"http,omitempty"`
-	MaxQos      byte   `json:"max_qos,omitempty" yaml:"max_qos,omitempty"`
-	Auth        *Auth  `json:"auth,omitempty" yaml:"auth,omitempty"`
+	Tls         *Tls     `json:"tls" yaml:"tls"`
+	TcpAddress  string   `json:"tcp,omitempty" yaml:"tcp,omitempty"`
+	HttpAddress string   `json:"http,omitempty" yaml:"http,omitempty"`
+	MaxQos      byte     `json:"max_qos,omitempty" yaml:"max_qos,omitempty"`
+	Auth        *Auth    `json:"auth,omitempty" yaml:"auth,omitempty"`
+	Offline     *Offline `json:"offline,omitempty"`
 }
 
 // Tls stores the TLS config for the server
@@ -25,4 +26,10 @@ type Auth struct {
 	LdapHost string `json:"ldap_host,omitempty" yaml:"ldap_host,omitempty"`
 	LdapPort int    `json:"ldap_port,omitempty" yaml:"ldap_port,omitempty"`
 	LdapDn   string `json:"ldap_dn,omitempty" yaml:"ldap_dn,omitempty"`
+}
+
+type Offline struct {
+	Path         string `json:"path,omitempty"`
+	MaxTableSize int64  `json:"max_table_size,omitempty"`
+	NumTables    int    `json:"num_tables,omitempty"`
 }

--- a/lib/server_context.go
+++ b/lib/server_context.go
@@ -26,12 +26,12 @@ type ServerContext struct {
 func NewServerContext(config *config.Config) (*ServerContext, error) {
 	authProvider, err := auth.FetchProviderFromConfig(config)
 	if err != nil {
-		return nil, err
+		fmt.Println("auth provider setup failed:", err)
 	}
 
-	persistenceProvider, err := persistence.NewBadgerProvider()
+	persistenceProvider, err := persistence.NewBadgerProvider(config)
 	if err != nil {
-		return nil, err
+		fmt.Println("persistence provider setup failed:", err)
 	}
 	return &ServerContext{
 		mu:                  &sync.RWMutex{},


### PR DESCRIPTION
Badger cache is now persisted on disk, which retain any undelivered
messages between server restarts and deliver when client connects later.

Signed-off-by: Chaitanya Munukutla <chaitanya.m61292@gmail.com>